### PR TITLE
Bugfix: corrigir e capturar erro de integridade referencial

### DIFF
--- a/backend/src/main/java/com/hextech/estoque_api/application/exceptions/DeletionConflictException.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/exceptions/DeletionConflictException.java
@@ -1,0 +1,7 @@
+package com.hextech.estoque_api.application.exceptions;
+
+public class DeletionConflictException extends RuntimeException {
+    public DeletionConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/handlers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/handlers/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.hextech.estoque_api.interfaces.handlers;
 
+import com.hextech.estoque_api.application.exceptions.DeletionConflictException;
 import com.hextech.estoque_api.application.exceptions.InvalidMovementTypeException;
 import com.hextech.estoque_api.application.exceptions.ResourceNotFoundException;
 import com.hextech.estoque_api.infrastructure.security.exceptions.InvalidJwtAuthenticationException;
@@ -47,6 +48,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidMovementTypeException.class)
     public ResponseEntity<CustomError> handleInvalidMovementType(InvalidMovementTypeException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.BAD_REQUEST;
+        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
+        return ResponseEntity.status(status).body(error);
+    }
+
+    @ExceptionHandler(DeletionConflictException.class)
+    public ResponseEntity<CustomError> handleDeletionConflict(DeletionConflictException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.CONFLICT;
         CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(status).body(error);
     }

--- a/backend/src/main/resources/db/migration/V2__create_user_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_user_table.sql
@@ -6,5 +6,5 @@ create table users (
     enabled boolean not null,
     company_id bigint,
     primary key (id),
-    foreign key (company_id) references companies(id) on delete set null
+    foreign key (company_id) references companies(id)
     );

--- a/backend/src/main/resources/db/migration/V5__create_stock_location_table.sql
+++ b/backend/src/main/resources/db/migration/V5__create_stock_location_table.sql
@@ -3,5 +3,5 @@ create table stock_locations (
     name varchar(255) not null,
     company_id bigint,
     primary key (id),
-    foreign key (company_id) references companies(id) on delete set null
+    foreign key (company_id) references companies(id)
     );

--- a/backend/src/main/resources/db/migration/V6__create_product_table.sql
+++ b/backend/src/main/resources/db/migration/V6__create_product_table.sql
@@ -7,6 +7,6 @@ create table products (
     stock_location_id bigint,
     company_id bigint,
     primary key (id),
-    foreign key (company_id) references companies(id) on delete set null,
-    foreign key (stock_location_id) references stock_locations(id) on delete set null
+    foreign key (company_id) references companies(id),
+    foreign key (stock_location_id) references stock_locations(id)
     );

--- a/backend/src/main/resources/db/migration/V7__create_movement_table.sql
+++ b/backend/src/main/resources/db/migration/V7__create_movement_table.sql
@@ -9,8 +9,8 @@ create table movements (
     user_id bigint,
     company_id bigint,
     primary key (id),
-    foreign key (company_id) references companies(id) on delete set null,
-    foreign key (product_id) references products(id) on delete set null,
-    foreign key (stock_location_id) references stock_locations(id) on delete set null,
-    foreign key (user_id) references users(id) on delete set null
+    foreign key (company_id) references companies(id),
+    foreign key (product_id) references products(id),
+    foreign key (stock_location_id) references stock_locations(id),
+    foreign key (user_id) references users(id)
     );

--- a/backend/src/main/resources/import.sql
+++ b/backend/src/main/resources/import.sql
@@ -1,24 +1,24 @@
-INSERT INTO clients (name, cnpj, enabled) VALUES ('Cliente Teste 1', '83981157000172', true);
-INSERT INTO clients (name, cnpj, enabled) VALUES ('Cliente Teste 2', '12345678000195', true);
+INSERT INTO companies (name, cnpj, enabled) VALUES ('Empresa Teste 1', '83981157000172', true);
+INSERT INTO companies (name, cnpj, enabled) VALUES ('Empresa Teste 2', '12345678000195', true);
 
-INSERT INTO users (name, email, password, client_id, enabled) VALUES ('Nathan', 'nathan@gmail.com', '{pbkdf2}2d8e93af5a655ab01ad676fe44cffb9f1fb23dec17ff6b97b6491428bb785c1963f69959dce30e90', 1, true);
-INSERT INTO users (name, email, password, client_id, enabled) VALUES ('Natan', 'natan@gmail.com', '{pbkdf2}2d8e93af5a655ab01ad676fe44cffb9f1fb23dec17ff6b97b6491428bb785c1963f69959dce30e90', 2, true);
+INSERT INTO users (name, email, password, company_id, enabled) VALUES ('Nathan', 'nathan@gmail.com', '{pbkdf2}2d8e93af5a655ab01ad676fe44cffb9f1fb23dec17ff6b97b6491428bb785c1963f69959dce30e90', 1, true);
+INSERT INTO users (name, email, password, company_id, enabled) VALUES ('Natan', 'natan@gmail.com', '{pbkdf2}2d8e93af5a655ab01ad676fe44cffb9f1fb23dec17ff6b97b6491428bb785c1963f69959dce30e90', 2, true);
 
 INSERT INTO roles (authority) VALUES ('ROLE_ADMIN');
 
 INSERT INTO user_role (user_id, role_id) VALUES (1, 1);
 INSERT INTO user_role (user_id, role_id) VALUES (2, 1);
 
-INSERT INTO stock_locations (name, client_id) VALUES ('Armazem 1', 1);
-INSERT INTO stock_locations (name, client_id) VALUES ('Galpão 1', 2);
+INSERT INTO stock_locations (name, company_id) VALUES ('Armazem 1', 1);
+INSERT INTO stock_locations (name, company_id) VALUES ('Galpão 1', 2);
 
-INSERT INTO products (name, price, quantity, unit_measure, client_id, stock_location_id) VALUES ('Camisa P', 100.80, 500, 1, 1, 1);
-INSERT INTO products (name, price, quantity, unit_measure, client_id, stock_location_id) VALUES ('Calça M', 150, 500, 1, 2, 2);
+INSERT INTO products (name, price, quantity, unit_measure, company_id, stock_location_id) VALUES ('Camisa P', 100.80, 500, 1, 1, 1);
+INSERT INTO products (name, price, quantity, unit_measure, company_id, stock_location_id) VALUES ('Calça M', 150, 500, 1, 2, 2);
 
-INSERT INTO movements (type, quantity, moment, note, product_id, user_id, client_id, stock_location_id) VALUES (0, 100, '2025-08-01', 'Entrada de produto', 1, 1, 1, 1);
-INSERT INTO movements (type, quantity, moment, note, product_id, user_id, client_id, stock_location_id) VALUES (0, 50, '2025-08-05', 'Entrada inicial de estoque', 1, 1, 1, 1);
-INSERT INTO movements (type, quantity, moment, note, product_id, user_id, client_id, stock_location_id) VALUES (1, 20, '2025-08-10', 'Saída para produção', 1, 1, 1, 1);
-INSERT INTO movements (type, quantity, moment, note, product_id, user_id, client_id, stock_location_id) VALUES (0, 200, '2025-08-15', 'Reposição de fornecedor', 2, 2, 2, 2);
-INSERT INTO movements (type, quantity, moment, note, product_id, user_id, client_id, stock_location_id) VALUES (1, 75, '2025-08-20', 'Venda de materiais', 2, 2, 2, 2);
-INSERT INTO movements (type, quantity, moment, note, product_id, user_id, client_id, stock_location_id) VALUES (0, 30, '2025-08-25', 'Devolução de cliente', 1, 1, 1, 1);
-INSERT INTO movements (type, quantity, moment, note, product_id, user_id, client_id, stock_location_id) VALUES (1, 10, '2025-08-28', 'Consumo interno', 1, 1, 1, 1);
+INSERT INTO movements (type, quantity, moment, note, product_id, user_id, company_id, stock_location_id) VALUES (0, 100, '2025-08-01', 'Entrada de produto', 1, 1, 1, 1);
+INSERT INTO movements (type, quantity, moment, note, product_id, user_id, company_id, stock_location_id) VALUES (0, 50, '2025-08-05', 'Entrada inicial de estoque', 1, 1, 1, 1);
+INSERT INTO movements (type, quantity, moment, note, product_id, user_id, company_id, stock_location_id) VALUES (1, 20, '2025-08-10', 'Saída para produção', 1, 1, 1, 1);
+INSERT INTO movements (type, quantity, moment, note, product_id, user_id, company_id, stock_location_id) VALUES (0, 200, '2025-08-15', 'Reposição de fornecedor', 2, 2, 2, 2);
+INSERT INTO movements (type, quantity, moment, note, product_id, user_id, company_id, stock_location_id) VALUES (1, 75, '2025-08-20', 'Venda de materiais', 2, 2, 2, 2);
+INSERT INTO movements (type, quantity, moment, note, product_id, user_id, company_id, stock_location_id) VALUES (0, 30, '2025-08-25', 'Devolução de cliente', 1, 1, 1, 1);
+INSERT INTO movements (type, quantity, moment, note, product_id, user_id, company_id, stock_location_id) VALUES (1, 10, '2025-08-28', 'Consumo interno', 1, 1, 1, 1);


### PR DESCRIPTION
Este PR corrige um problema na exclusão de entidades relacionadas. Agora, quando houver registros vinculados a uma entidade, a exclusão não será permitida.