### PR TITLE
fix: Corrige tratamento de erros de autenticacao JWT

### DIFF
--- a/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/configs/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/configs/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.hextech.estoque_api.infrastructure.security.configs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hextech.estoque_api.interfaces.dtos.StarndardResponse.StandardResponse;
+import com.hextech.estoque_api.interfaces.dtos.errors.CustomError;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        String errorMessage;
+        if (authException instanceof InsufficientAuthenticationException) {
+            errorMessage = "Autenticação necessária. Insira um token válido.";
+        } else {
+            errorMessage = authException.getMessage();
+        }
+
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        CustomError error = new CustomError(Instant.now().toString(), status.value(), errorMessage, request.getRequestURI());
+        StandardResponse<CustomError> standardResponse = new StandardResponse<>(false, List.of(error));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writeValue(response.getOutputStream(), standardResponse);
+    }
+}

--- a/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/exceptions/InvalidJwtAuthenticationException.java
+++ b/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/exceptions/InvalidJwtAuthenticationException.java
@@ -1,6 +1,11 @@
 package com.hextech.estoque_api.infrastructure.security.exceptions;
 
-public class InvalidJwtAuthenticationException extends RuntimeException {
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidJwtAuthenticationException extends AuthenticationException {
+    public InvalidJwtAuthenticationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
     public InvalidJwtAuthenticationException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/jwt/JwtTokenFilter.java
+++ b/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/jwt/JwtTokenFilter.java
@@ -1,36 +1,48 @@
 package com.hextech.estoque_api.infrastructure.security.jwt;
 
+import com.hextech.estoque_api.infrastructure.security.exceptions.InvalidJwtAuthenticationException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-public class JwtTokenFilter extends GenericFilterBean {
+@Component
+public class JwtTokenFilter extends OncePerRequestFilter {
 
     @Autowired
     private JwtTokenProvider tokenProvider;
+    @Autowired
+    @Qualifier("customAuthenticationEntryPoint")
+    private AuthenticationEntryPoint customAuthenticationEntryPoint;
 
+    @Autowired
     public JwtTokenFilter(JwtTokenProvider tokenProvider) {
         this.tokenProvider = tokenProvider;
     }
 
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        var token = tokenProvider.resolveToken((HttpServletRequest) servletRequest);
-        if(StringUtils.isNotBlank(token) && tokenProvider.validateToken(token)) {
-            Authentication authentication = tokenProvider.getAuthentication(token);
-            if(authentication != null) {
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            var token = tokenProvider.resolveToken(request);
+            if(StringUtils.isNotBlank(token) && tokenProvider.validateToken(token)) {
+                Authentication authentication = tokenProvider.getAuthentication(token);
+                if(authentication != null) {
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
+            filterChain.doFilter(request, response);
+        } catch (InvalidJwtAuthenticationException e) {
+            this.customAuthenticationEntryPoint.commence(request, response, e);
         }
-            filterChain.doFilter(servletRequest, servletResponse);
     }
 }

--- a/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/hextech/estoque_api/infrastructure/security/jwt/JwtTokenProvider.java
@@ -82,7 +82,7 @@ public class JwtTokenProvider {
             }
             return true;
         } catch (Exception e) {
-            throw new InvalidJwtAuthenticationException("Token inválido ou expirado");
+            throw new InvalidJwtAuthenticationException("Token inválido ou expirado", e);
         }
     }
 

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/errors/CustomError.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/errors/CustomError.java
@@ -2,5 +2,5 @@ package com.hextech.estoque_api.interfaces.dtos.errors;
 
 import java.time.Instant;
 
-public record CustomError(Instant timestamp, Integer status, String message, String path) {
+public record CustomError(String timestamp, Integer status, String message, String path) {
 }

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/handlers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/handlers/GlobalExceptionHandler.java
@@ -1,13 +1,11 @@
 package com.hextech.estoque_api.interfaces.handlers;
 
 import com.hextech.estoque_api.domain.exceptions.*;
-import com.hextech.estoque_api.infrastructure.security.exceptions.InvalidJwtAuthenticationException;
 import com.hextech.estoque_api.interfaces.dtos.StarndardResponse.StandardResponse;
 import com.hextech.estoque_api.interfaces.dtos.errors.CustomError;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -17,59 +15,45 @@ import java.util.List;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(InvalidJwtAuthenticationException.class)
-    public ResponseEntity<StandardResponse<?>> handleInvalidJwt(InvalidJwtAuthenticationException ex, HttpServletRequest request) {
-        HttpStatus status = HttpStatus.UNAUTHORIZED;
-        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
-        return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
-    }
-
-    @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<StandardResponse<?>> handleBadCredentials(BadCredentialsException ex, HttpServletRequest request) {
-        HttpStatus status = HttpStatus.FORBIDDEN;
-        CustomError error = new CustomError(Instant.now(), status.value(), "Usuário ou senha inválido!", request.getRequestURI());
-        return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
-    }
-
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<StandardResponse<?>> handleResourceNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.NOT_FOUND;
-        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
+        CustomError error = new CustomError(Instant.now().toString(), status.value(), ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<StandardResponse<?>> handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
+        CustomError error = new CustomError(Instant.now().toString(), status.value(), ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
     }
 
     @ExceptionHandler(InvalidMovementTypeException.class)
     public ResponseEntity<StandardResponse<?>> handleInvalidMovementType(InvalidMovementTypeException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
+        CustomError error = new CustomError(Instant.now().toString(), status.value(), ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
     }
 
     @ExceptionHandler(DeletionConflictException.class)
     public ResponseEntity<StandardResponse<?>> handleDeletionConflict(DeletionConflictException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.CONFLICT;
-        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
+        CustomError error = new CustomError(Instant.now().toString(), status.value(), ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
     }
 
     @ExceptionHandler(UserAlreadyExistsException.class)
     public ResponseEntity<StandardResponse<?>> handleUserAlreadyExists(UserAlreadyExistsException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.CONFLICT;
-        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
+        CustomError error = new CustomError(Instant.now().toString(), status.value(), ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
     }
 
     @ExceptionHandler(InvalidUnitMeasureException.class)
     public ResponseEntity<StandardResponse<?>> handleInvalidUnitMeasure(InvalidUnitMeasureException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        CustomError error = new CustomError(Instant.now(), status.value(), ex.getMessage(), request.getRequestURI());
+        CustomError error = new CustomError(Instant.now().toString(), status.value(), ex.getMessage(), request.getRequestURI());
         return ResponseEntity.status(status).body(new StandardResponse<>(false, List.of(error)));
     }
 }


### PR DESCRIPTION
Este Pull Request aborda um comportamento de erro inconsistente na autenticação via token JWT. A solução implementa um tratamento de exceção robusto no filtro de segurança, garantindo que qualquer falha na validação do token — seja por ausência ou por ser inválido — retorne uma resposta HTTP 401 Unauthorized padronizada. As alterações garantem que o CustomAuthenticationEntryPoint seja sempre invocado para fornecer mensagens de erro claras e um formato JSON consistente, melhorando a experiência do cliente da API e corrigindo o erro 500 Internal Server Error que ocorria em cenários de token inválido.