### PR TITLE
feat: adiciona parâmetro de nome na busca paginada de produtos

### DIFF
--- a/backend/src/main/java/com/hextech/estoque_api/application/services/ProductService.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/services/ProductService.java
@@ -30,8 +30,8 @@ public class ProductService {
     private StockLocationRepository stockLocationRepository;
 
     @Transactional(readOnly = true)
-    public Page<ProductResponseDTO> findAllByCompanyId(Long currentCompanyId, Pageable pageable) {
-        Page<Product> products = repository.findAllByCompanyId(currentCompanyId, pageable);
+    public Page<ProductResponseDTO> findAllByCompanyId(String name, Long currentCompanyId, Pageable pageable) {
+        Page<Product> products = repository.findAllByNameAndCompanyId(name, currentCompanyId, pageable);
         return products.map(ProductResponseDTO::new);
     }
 

--- a/backend/src/main/java/com/hextech/estoque_api/infrastructure/repositories/ProductRepository.java
+++ b/backend/src/main/java/com/hextech/estoque_api/infrastructure/repositories/ProductRepository.java
@@ -4,6 +4,7 @@ import com.hextech.estoque_api.domain.entities.product.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,7 +12,12 @@ import java.util.Optional;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    Page<Product> findAllByCompanyId(Long companyId, Pageable pageable);
+    @Query(value = """
+            SELECT p FROM Product p
+            WHERE UPPER(p.name) LIKE UPPER(CONCAT('%', :name, '%'))
+            AND p.company.id = :companyId
+            """)
+    Page<Product> findAllByNameAndCompanyId(String name, Long companyId, Pageable pageable);
 
     Optional<Product> findByIdAndCompanyId(Long id, Long companyId);
 }

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/ProductController.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/ProductController.java
@@ -30,10 +30,10 @@ public class ProductController implements ProductControllerDocs {
     private ProductService service;
 
     @GetMapping
-    public ResponseEntity<StandardResponse<?>> findAllPaged(Pageable pageable) {
+    public ResponseEntity<StandardResponse<?>> findAllPaged(@RequestParam(value = "name", defaultValue = "") String name, Pageable pageable) {
         int page = pageable.getPageNumber() > 0 ? pageable.getPageNumber() - 1 : 0;
         Pageable adjustedPageable = PageRequest.of(page, pageable.getPageSize(), pageable.getSort());
-        Page<ProductResponseDTO> response = service.findAllByCompanyId(authContext.getCurrentCompanyId(), adjustedPageable);
+        Page<ProductResponseDTO> response = service.findAllByCompanyId(name, authContext.getCurrentCompanyId(), adjustedPageable);
 
         List<ProductResponseDTO> content = response.getContent();
         PageMetadata pageMetadata = new PageMetadata(response);

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/docs/ProductControllerDocs.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/docs/ProductControllerDocs.java
@@ -20,7 +20,7 @@ public interface ProductControllerDocs {
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
     })
-    ResponseEntity<StandardResponse<?>> findAllPaged(Pageable pageable);
+    ResponseEntity<StandardResponse<?>> findAllPaged(String name, Pageable pageable);
 
     @Operation(summary = "Busca um produto pelo ID")
     @ApiResponses(value = {

--- a/backend/src/test/java/com/hextech/estoque_api/application/services/ProductServiceTest.java
+++ b/backend/src/test/java/com/hextech/estoque_api/application/services/ProductServiceTest.java
@@ -46,17 +46,19 @@ class ProductServiceTest {
     @Test
     @DisplayName("Should return all products paged for the current company")
     void findAllByCompanyIdPagedCase1() {
+        Product product = ProductFactory.createProduct(1L);
+        String productName = product.getName();
         Long companyId = 1L;
         long totalElements = 1;
 
         Pageable pageable = PageRequest.of(0, 8);
-        Page<Product> page = new PageImpl<>(List.of(ProductFactory.createProduct(1L)), pageable, totalElements);
+        Page<Product> page = new PageImpl<>(List.of(product), pageable, totalElements);
 
-        when(repository.findAllByCompanyId(anyLong(), any())).thenReturn(page);
+        when(repository.findAllByNameAndCompanyId(any(), anyLong(), any())).thenReturn(page);
 
-        Page<ProductResponseDTO> result = service.findAllByCompanyId(companyId, pageable);
+        Page<ProductResponseDTO> result = service.findAllByCompanyId(productName, companyId, pageable);
 
-        verify(repository, times(1)).findAllByCompanyId(anyLong(), any());
+        verify(repository, times(1)).findAllByNameAndCompanyId(any(), anyLong(), any());
         assertNotNull(result);
         assertEquals(1, result.getTotalElements());
         assertEquals(1, result.getContent().size());


### PR DESCRIPTION
Este PR implementa a funcionalidade de busca por nome na API de produtos paginada. Com essa feature, agora é possível passar um novo parâmetro de consulta (query parameter) contendo o nome ou parte do nome do produto desejado. Isso otimiza significativamente a experiência do usuário ao refinar as buscas e permite a filtragem direta dos resultados na paginação, tornando o processo de encontrar produtos mais rápido e eficiente.