### PR TITLE
Feature/implementa relatorios em pdf

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -56,12 +56,13 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+		<!--Security-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
         <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-test</artifactId>
@@ -72,6 +73,7 @@
             <artifactId>java-jwt</artifactId>
             <version>4.4.0</version>
         </dependency>
+		<!--Database-->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -87,6 +89,17 @@
             <artifactId>flyway-core</artifactId>
             <version>9.5.1</version>
         </dependency>
+		<!--pdf-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.xhtmlrenderer</groupId>
+			<artifactId>flying-saucer-pdf</artifactId>
+			<version>9.1.22</version>
+		</dependency>
+		<!--Documentation-->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>

--- a/backend/src/main/java/com/hextech/estoque_api/application/factories/ReportPeriodFactory.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/factories/ReportPeriodFactory.java
@@ -1,6 +1,7 @@
 package com.hextech.estoque_api.application.factories;
 
 import com.hextech.estoque_api.domain.entities.ReportPeriod;
+import com.hextech.estoque_api.domain.exceptions.BusinessException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -13,10 +14,7 @@ public class ReportPeriodFactory {
 
         try {
             LocalDate end = (endDate.isEmpty() || endDate.equals("null")) ? now : LocalDate.parse(endDate);
-            LocalDate start = (startDate.isEmpty() || startDate.equals("null")) ?
-                    LocalDate.of(end.getYear(), end.getMonth().minus(1), end.getDayOfMonth()) : LocalDate.parse(startDate);
-
-            if (start.isAfter(end)) throw new IllegalArgumentException("Data inicial não pode ser posterior a data final.");
+            LocalDate start = getLocalDate(startDate, end, now);
 
             return new ReportPeriod(
                     LocalDateTime.of(start.getYear(), start.getMonth(), start.getDayOfMonth(), 0, 0),
@@ -25,5 +23,17 @@ public class ReportPeriodFactory {
         } catch (DateTimeParseException e) {
             throw new IllegalArgumentException("Datas inválidas. Use o formato yyyy-MM-dd.");
         }
+    }
+
+    private static LocalDate getLocalDate(String startDate, LocalDate end, LocalDate now) {
+        LocalDate start = (startDate.isEmpty() || startDate.equals("null")) ?
+                end.minusMonths(1) : LocalDate.parse(startDate);
+
+        if (start.isAfter(end)) throw new BusinessException("Data inicial não pode ser posterior a data final.");
+
+        if (start.isAfter(now) || end.isAfter(now)) throw new BusinessException("Datas não podem ser maiores que a data atual.");
+
+        if (start.plusYears(1).isBefore(end)) throw new BusinessException("Período não pode ser maior que 1 ano.");
+        return start;
     }
 }

--- a/backend/src/main/java/com/hextech/estoque_api/application/services/MovementReportService.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/services/MovementReportService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.hextech.estoque_api.application.services.ProductService.parseProductId;
@@ -31,5 +32,25 @@ public class MovementReportService {
         Page<Movement> movements = repository.searchAllMovements(period.getStartDate(), period.getEndDate(), checkedType,
                 productIdParsed, companyId, validPageable);
         return movements.map(MovementResponseDTO::new);
+    }
+
+    public List<MovementResponseDTO> getMovementsReportToPdf(String startDate, String endDate, String type, String productId, Long companyId, Pageable pageable) {
+        ReportPeriod period = ReportPeriodFactory.fromString(startDate, endDate);
+        Long productIdParsed = parseProductId(productId);
+        MovementType checkedType = (type.isEmpty() || type.equals("null")) ? null : MovementType.checkMovementType(type);
+        Pageable validPageable = PageableUtils.validatePageable(pageable, List.of("id", "type", "moment"));
+
+        List<Movement> allMovements = new ArrayList<>();
+        Page<Movement> page;
+        do {
+            page = repository.searchAllMovements(period.getStartDate(), period.getEndDate(), checkedType,
+                    productIdParsed, companyId, validPageable);
+
+            allMovements.addAll(page.getContent());
+
+            validPageable = validPageable.next();
+        } while (page.hasNext());
+
+        return allMovements.stream().map(MovementResponseDTO::new).toList();
     }
 }

--- a/backend/src/main/java/com/hextech/estoque_api/application/services/PdfService.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/services/PdfService.java
@@ -1,0 +1,43 @@
+package com.hextech.estoque_api.application.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+import java.io.ByteArrayOutputStream;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+public class PdfService {
+
+    @Autowired
+    private SpringTemplateEngine templateEngine;
+
+    public byte[] createPdf(String template, Map<String, Object> variables) {
+        Context context = new Context();
+        variables.forEach(context::setVariable);
+        context.setVariable("now", LocalDateTime.now());
+
+        String html = templateEngine.process(template, context);
+
+        return generatePdfFromHtml(html);
+    }
+
+    private byte[] generatePdfFromHtml(String html) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+            ITextRenderer renderer = new ITextRenderer();
+            renderer.setDocumentFromString(html);
+            renderer.layout();
+            renderer.createPDF(outputStream);
+
+            return outputStream.toByteArray();
+
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao gerar PDF.", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/hextech/estoque_api/application/services/ProductReportService.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/services/ProductReportService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -29,5 +30,23 @@ public class ProductReportService {
         Page<Product> productsPage = repository.searchProductsReport(parsedStatus, companyId, validPageable);
 
         return productsPage.map(ProductReportDTO::new);
+    }
+
+    public List<ProductReportDTO> getProductsReportToPdf(String status, Long companyId, Pageable pageable) {
+
+        String parsedStatus = (status == null || status.isBlank()) ? null : StockStatus.checkStockStatus(status).name();
+
+        Pageable validPageable = PageableUtils.validatePageable(pageable, List.of("id", "code", "name", "price"));
+
+        List<Product> allProducts = new ArrayList<>();
+        Page<Product> page;
+        do {
+            page = repository.searchProductsReport(parsedStatus, companyId, validPageable);
+            allProducts.addAll(page.getContent());
+            validPageable = validPageable.next();
+        } while (page.hasNext());
+
+
+        return allProducts.stream().map(ProductReportDTO::new).toList();
     }
 }

--- a/backend/src/main/java/com/hextech/estoque_api/domain/entities/product/StockStatus.java
+++ b/backend/src/main/java/com/hextech/estoque_api/domain/entities/product/StockStatus.java
@@ -1,9 +1,18 @@
 package com.hextech.estoque_api.domain.entities.product;
 
+import lombok.Getter;
+
+@Getter
 public enum StockStatus {
-        LOW,
-        NORMAL,
-        HIGH;
+        LOW("BAIXO"),
+        NORMAL("NORMAL"),
+        HIGH("ALTO");
+
+        private final String description;
+
+        StockStatus(String description) {
+            this.description = description;
+        }
 
     public static StockStatus checkStockStatus(String status) {
         try {

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/MovementReportController.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/MovementReportController.java
@@ -1,6 +1,7 @@
 package com.hextech.estoque_api.interfaces.controllers;
 
 import com.hextech.estoque_api.application.services.MovementReportService;
+import com.hextech.estoque_api.application.services.PdfService;
 import com.hextech.estoque_api.infrastructure.utils.AuthContext;
 import com.hextech.estoque_api.interfaces.controllers.docs.MovementReportControllerDocs;
 import com.hextech.estoque_api.interfaces.dtos.StarndardResponse.PageMetadata;
@@ -10,6 +11,7 @@ import com.hextech.estoque_api.interfaces.dtos.movements.MovementResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping(value = "/api/reports/movements", produces = "application/json")
@@ -26,6 +29,8 @@ public class MovementReportController implements MovementReportControllerDocs {
     private AuthContext auth;
     @Autowired
     private MovementReportService movementReportService;
+    @Autowired
+    private PdfService pdfService;
 
     @GetMapping
     public ResponseEntity<StandardResponse<?>> reportMovements(
@@ -45,4 +50,25 @@ public class MovementReportController implements MovementReportControllerDocs {
         PaginatedResponse<MovementResponseDTO> paginatedResponse = new PaginatedResponse<>(content, pageMetadata);
         return ResponseEntity.ok(new StandardResponse<>(true, paginatedResponse));
     }
+
+    @GetMapping(produces = MediaType.APPLICATION_PDF_VALUE)
+    public ResponseEntity<byte[]> reportMovementsPdf(
+            @RequestParam(value = "startDate", defaultValue = "") String startDate,
+            @RequestParam(value = "endDate", defaultValue = "") String endDate,
+            @RequestParam(value = "type", defaultValue = "") String type,
+            @RequestParam(value = "productId", defaultValue = "") String productId,
+            Pageable pageable
+    ) {
+
+        List<MovementResponseDTO> response = movementReportService.getMovementsReportToPdf(startDate, endDate, type,
+                productId, auth.getCurrentCompanyId(), pageable);
+
+        byte[] pdf = pdfService.createPdf("movement-report", Map.of("movements", response));
+
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=movimentacoes.pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
+    }
+
 }

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/ProductReportController.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/ProductReportController.java
@@ -1,5 +1,6 @@
 package com.hextech.estoque_api.interfaces.controllers;
 
+import com.hextech.estoque_api.application.services.PdfService;
 import com.hextech.estoque_api.application.services.ProductReportService;
 import com.hextech.estoque_api.infrastructure.utils.AuthContext;
 import com.hextech.estoque_api.interfaces.dtos.StarndardResponse.PageMetadata;
@@ -9,6 +10,7 @@ import com.hextech.estoque_api.interfaces.dtos.products.ProductReportDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping(value = "/api/reports/products", produces = "application/json")
@@ -25,6 +28,8 @@ public class ProductReportController {
     private AuthContext auth;
     @Autowired
     private ProductReportService productReportService;
+    @Autowired
+    private PdfService pdfService;
 
     @GetMapping
     public ResponseEntity<StandardResponse<?>> reportProducts(
@@ -36,5 +41,18 @@ public class ProductReportController {
 
         PaginatedResponse<?> paginatedResponse = new PaginatedResponse<>(content, pageMetadata);
         return ResponseEntity.ok(new StandardResponse<>(true, paginatedResponse));
+    }
+
+    @GetMapping(produces = "application/pdf")
+    public ResponseEntity<byte[]> reportProductsPdf(
+            @RequestParam(value = "status", defaultValue = "") String status, Pageable pageable) {
+        List<ProductReportDTO> response = productReportService.getProductsReportToPdf(status, auth.getCurrentCompanyId(), pageable);
+
+        byte[] pdf = pdfService.createPdf("product-report", Map.of("products", response));
+
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=produtos.pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
     }
 }

--- a/backend/src/main/resources/templates/movement-report.html
+++ b/backend/src/main/resources/templates/movement-report.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:td="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8"/>
+    <style>
+        @page {
+            size: A4 landscape;
+        }
+
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+            color: #333;
+        }
+
+        .container {
+            padding: 20px;
+        }
+
+        /* HEADER */
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 2px solid #ddd;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+        }
+
+        .title {
+            font-size: 20px;
+            font-weight: bold;
+        }
+
+        .date {
+            font-size: 11px;
+            color: #777;
+        }
+
+        /* INFO */
+        .info {
+            display: inline;
+            margin-bottom: 20px;
+        }
+
+        .info span {
+            display: block;
+            margin-bottom: 5px;
+        }
+
+        /* TABLE */
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        thead {
+            background-color: #f5f5f5;
+        }
+
+        th {
+            text-align: center;
+            padding: 10px;
+            font-size: 12px;
+            border-bottom: 2px solid #ddd;
+        }
+
+        td {
+            padding: 8px;
+            text-align: center;
+            border-bottom: 1px solid #eee;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            font-size: 12px;
+        }
+
+        tr:nth-child(even) {
+            background-color: #fafafa;
+        }
+
+        /* FOOTER */
+        .footer {
+            margin-top: 30px;
+            font-size: 10px;
+            text-align: center;
+            color: #999;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+
+        <!-- HEADER -->
+        <div class="header">
+            <div class="title">Relatório de Movimentações</div>
+            <div class="date"
+                 th:text="${#temporals.format(now, 'dd/MM/yyyy HH:mm')}">
+            </div>
+        </div>
+
+        <!-- FILTROS -->
+        <div class="info">
+            <span>
+                <strong>Total de registros:</strong>
+                <span th:text="${movements.size()}"></span>
+            </span>
+        </div>
+
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Data</th>
+            <th>Tipo</th>
+            <th>Código</th>
+            <th>Produto</th>
+            <th>Quant.</th>
+            <th>Origem</th>
+            <th>Destino</th>
+            <th>Usuário</th>
+        </tr>
+        </thead>
+        <tbody>
+            <tr th:each="mov : ${movements}">
+                <td th:text="${mov.id}"></td>
+
+                <td th:text="${#temporals.format(mov.moment, 'dd/MM/yyyy HH:mm')}"></td>
+
+                <td th:text="${mov.type.toUpperCase()}"></td>
+
+                <td th:text="${mov.product.code}"></td>
+
+                <td style="text-align: left;" th:text="${mov.product.name}"></td>
+
+                <td th:text="${T(java.lang.String).format(new java.util.Locale('pt', 'BR'), '%.2f', mov.quantity)}"></td>
+
+                <td th:text="${mov.fromStockLocation != null ? mov.fromStockLocation.name : '-'}"></td>
+
+                <td th:text="${mov.toStockLocation != null ? mov.toStockLocation.name : '-'}"></td>
+
+                <td th:text="${mov.user.name.split(' ')[0]}"></td>
+
+            </tr>
+        </tbody>
+    </table>
+        <!-- FOOTER -->
+        <div class="footer">
+            Gerado automaticamente pelo sistema de estoque
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/movement-report.html
+++ b/backend/src/main/resources/templates/movement-report.html
@@ -39,13 +39,11 @@
 
         /* INFO */
         .info {
-            display: inline;
+            display: inline-block;
+            width: 100%;
+            margin-top: 15px;
             margin-bottom: 20px;
-        }
-
-        .info span {
-            display: block;
-            margin-bottom: 5px;
+            text-align: left;
         }
 
         /* TABLE */
@@ -98,14 +96,6 @@
             </div>
         </div>
 
-        <!-- FILTROS -->
-        <div class="info">
-            <span>
-                <strong>Total de registros:</strong>
-                <span th:text="${movements.size()}"></span>
-            </span>
-        </div>
-
     <table>
         <thead>
         <tr>
@@ -143,6 +133,15 @@
             </tr>
         </tbody>
     </table>
+
+        <!-- FILTROS -->
+        <div class="info">
+            <span>
+                <strong>Total de registros:</strong>
+                <span th:text="${movements.size()}"></span>
+            </span>
+        </div>
+
         <!-- FOOTER -->
         <div class="footer">
             Gerado automaticamente pelo sistema de estoque

--- a/backend/src/main/resources/templates/movement-report.html
+++ b/backend/src/main/resources/templates/movement-report.html
@@ -5,6 +5,11 @@
     <style>
         @page {
             size: A4 landscape;
+
+            @bottom-right {
+                content: "Página " counter(page) " de " counter(pages);
+                font-size: 10px;
+            }
         }
 
         body {

--- a/backend/src/main/resources/templates/product-report.html
+++ b/backend/src/main/resources/templates/product-report.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:td="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8"/>
+    <style>
+
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+            color: #333;
+        }
+
+        .container {
+            padding: 20px;
+        }
+
+        /* HEADER */
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 2px solid #ddd;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+        }
+
+        .title {
+            font-size: 20px;
+            font-weight: bold;
+        }
+
+        .date {
+            font-size: 11px;
+            color: #777;
+        }
+
+        /* INFO */
+        .info {
+            display: inline-block;
+            width: 100%;
+            margin-top: 15px;
+            margin-bottom: 20px;
+            text-align: left;
+        }
+
+        /* TABLE */
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        thead {
+            background-color: #f5f5f5;
+        }
+
+        th {
+            text-align: center;
+            padding: 10px;
+            font-size: 12px;
+            border-bottom: 2px solid #ddd;
+        }
+
+        td {
+            padding: 8px;
+            text-align: center;
+            border-bottom: 1px solid #eee;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            font-size: 12px;
+        }
+
+        tr:nth-child(even) {
+            background-color: #fafafa;
+        }
+
+        /* FOOTER */
+        .footer {
+            margin-top: 30px;
+            font-size: 10px;
+            text-align: center;
+            color: #999;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+
+    <!-- HEADER -->
+    <div class="header">
+        <div class="title">Relatório de Produtos</div>
+        <div class="date"
+             th:text="${#temporals.format(now, 'dd/MM/yyyy HH:mm')}">
+        </div>
+    </div>
+
+    <table>
+        <thead>
+        <tr>
+            <th>Código</th>
+            <th>Descrição</th>
+            <th>Preço</th>
+            <th>Quant.</th>
+            <th>U.M.</th>
+            <th>Status</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="prod : ${products}">
+            <td th:text="${prod.code}"></td>
+
+            <td style="text-align: left;" th:text="${prod.name}"></td>
+
+            <td th:text="${T(java.lang.String).format(new java.util.Locale('pt', 'BR'), '%.2f', prod.price)}"></td>
+
+            <td th:text="${T(java.lang.String).format(new java.util.Locale('pt', 'BR'), '%.2f', prod.totalQuantity)}"></td>
+
+            <td th:text="${prod.unitMeasure}"></td>
+
+            <td th:text="${prod.stockStatus.getDescription()}"></td>
+
+        </tr>
+        </tbody>
+    </table>
+
+    <!-- FILTROS -->
+    <div class="info">
+            <span>
+                <strong>Total de registros:</strong>
+                <span th:text="${products.size()}"></span>
+            </span>
+    </div>
+
+    <!-- FOOTER -->
+    <div class="footer">
+        Gerado automaticamente pelo sistema de estoque
+    </div>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/product-report.html
+++ b/backend/src/main/resources/templates/product-report.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8"/>
     <style>
 
+        @page {
+
+            @bottom-right {
+                content: "Página " counter(page) " de " counter(pages);
+                font-size: 10px;
+            }
+        }
+
         body {
             font-family: Arial, sans-serif;
             font-size: 12px;


### PR DESCRIPTION
## 📄 Relatórios em PDF (Movimentações e Produtos)

### ✨ O que foi feito

Este PR implementa a geração de relatórios em PDF para o sistema, contemplando tanto movimentações quanto produtos.

Foram adicionados endpoints para exportação dos dados, utilizando templates HTML renderizados com Thymeleaf e convertidos para PDF com Flying Saucer.

---

### 🚀 Funcionalidades

* Geração de relatório de **movimentações em PDF**
* Geração de relatório de **produtos em PDF**
* Paginação automática nos PDFs (ex: Página X de Y)
* Exibição do total de registros nos relatórios

---

### 🛠️ Implementações técnicas

* Integração do **Thymeleaf** para renderização de templates HTML
* Uso do **Flying Saucer** para conversão HTML → PDF
* Criação de um serviço genérico para geração de PDFs
* Templates reutilizáveis para diferentes tipos de relatório

---

### 📌 Observações

* A estrutura foi pensada de forma genérica, permitindo fácil expansão para novos relatórios
* A paginação é controlada via CSS, sem necessidade de lógica adicional no backend

---

### 🧪 Como testar

1. Acessar os endpoints de relatório:

   * `/api/reports/movements` + header: accept = application/json
   * `/api/reports/products` + header: accept = application/json
2. Verificar:

   * Geração correta do PDF
   * Paginação (rodapé com número de páginas)
   * Dados exibidos corretamente
   * Filtros de data funcionando (movements)

---

### 📷 Resultado esperado

Relatórios em PDF com:

* Layout organizado
* Tabela de dados
* Total de registros
* Paginação no rodapé

---
