### PR TITLE
implementa endpoint dashboard

### DIFF
--- a/backend/src/main/java/com/hextech/estoque_api/application/services/DashboardService.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/services/DashboardService.java
@@ -28,7 +28,8 @@ public class DashboardService {
 
         Long totalProducts = productRepository.countByCompanyId(companyId);
         Long lowStockCount = productRepository.countByCompanyIdAndStockStatus(companyId, "LOW");
-        List<Product> lowProducts = productRepository.findTop5ByStockStatus(companyId, "LOW", PageRequest.of(0, 5));
+        List<Product> lowProducts = productRepository
+                .findTop5ByStockStatus(companyId, "LOW", PageRequest.of(0, 5));
         Long totalMovements = movementRepository.countByCompanyId(companyId);
         List<Movement> recentMovements = movementRepository.findTop5ByCompanyIdOrderByMomentDesc(companyId);
         List<TopMovingProducts> topMovingProducts = movementRepository

--- a/backend/src/main/java/com/hextech/estoque_api/application/services/DashboardService.java
+++ b/backend/src/main/java/com/hextech/estoque_api/application/services/DashboardService.java
@@ -1,0 +1,41 @@
+package com.hextech.estoque_api.application.services;
+
+import com.hextech.estoque_api.domain.entities.movement.Movement;
+import com.hextech.estoque_api.domain.entities.product.Product;
+import com.hextech.estoque_api.infrastructure.repositories.MovementRepository;
+import com.hextech.estoque_api.infrastructure.repositories.ProductRepository;
+import com.hextech.estoque_api.interfaces.dtos.dashboard.DashboardDTO;
+import com.hextech.estoque_api.interfaces.dtos.dashboard.TopMovingProducts;
+import com.hextech.estoque_api.interfaces.dtos.movements.MovementMinDTO;
+import com.hextech.estoque_api.interfaces.dtos.products.ProductResumeDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class DashboardService {
+
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private MovementRepository movementRepository;
+
+    @Transactional(readOnly = true)
+    public DashboardDTO getDashboard(Long companyId) {
+
+        Long totalProducts = productRepository.countByCompanyId(companyId);
+        Long lowStockCount = productRepository.countByCompanyIdAndStockStatus(companyId, "LOW");
+        List<Product> lowProducts = productRepository.findTop5ByStockStatus(companyId, "LOW", PageRequest.of(0, 5));
+        Long totalMovements = movementRepository.countByCompanyId(companyId);
+        List<Movement> recentMovements = movementRepository.findTop5ByCompanyIdOrderByMomentDesc(companyId);
+        List<TopMovingProducts> topMovingProducts = movementRepository
+                .findMostMovedProducts(companyId, PageRequest.of(0, 5));
+
+        return new DashboardDTO(totalProducts, lowStockCount, totalMovements,
+                recentMovements.stream().map(MovementMinDTO::new).toList(), topMovingProducts,
+                lowProducts.stream().map(ProductResumeDTO::new).toList());
+    }
+}

--- a/backend/src/main/java/com/hextech/estoque_api/infrastructure/repositories/MovementRepository.java
+++ b/backend/src/main/java/com/hextech/estoque_api/infrastructure/repositories/MovementRepository.java
@@ -2,6 +2,7 @@ package com.hextech.estoque_api.infrastructure.repositories;
 
 import com.hextech.estoque_api.domain.entities.movement.Movement;
 import com.hextech.estoque_api.domain.entities.movement.MovementType;
+import com.hextech.estoque_api.interfaces.dtos.dashboard.TopMovingProducts;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface MovementRepository extends JpaRepository<Movement, Long> {
@@ -40,4 +42,19 @@ public interface MovementRepository extends JpaRepository<Movement, Long> {
             OR m.toStockLocation.id = :stockLocationId
             """)
     boolean existsMovementByStockLocationId(Long stockLocationId);
+
+    Long countByCompanyId(Long companyId);
+
+    List<Movement> findTop5ByCompanyIdOrderByMomentDesc(Long companyId);
+
+    @Query("""
+            SELECT new com.hextech.estoque_api.interfaces.dtos.dashboard.TopMovingProducts(
+                        m.product, COUNT(m)
+                        )
+            FROM Movement m
+            WHERE m.company.id = :companyId
+            GROUP BY m.product
+            ORDER BY COUNT(m) DESC
+            """)
+    List<TopMovingProducts> findMostMovedProducts(Long companyId, Pageable pageable);
 }

--- a/backend/src/main/java/com/hextech/estoque_api/infrastructure/repositories/ProductRepository.java
+++ b/backend/src/main/java/com/hextech/estoque_api/infrastructure/repositories/ProductRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -47,4 +48,16 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> searchProductsReport(@Param("status") String status,
                                        @Param("companyId") Long companyId,
                                        Pageable pageable);
+
+    Long countByCompanyId(Long companyId);
+
+    Long countByCompanyIdAndStockStatus(Long companyId, String status);
+
+    @Query(value = """
+            SELECT p FROM Product p
+            WHERE p.company.id = :companyId
+            AND p.stockStatus = :status
+            ORDER BY p.totalQuantity DESC
+            """)
+    List<Product> findTop5ByStockStatus(Long companyId, String status, Pageable pageable);
 }

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/DashboardController.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/DashboardController.java
@@ -1,0 +1,27 @@
+package com.hextech.estoque_api.interfaces.controllers;
+
+import com.hextech.estoque_api.application.services.DashboardService;
+import com.hextech.estoque_api.infrastructure.utils.AuthContext;
+import com.hextech.estoque_api.interfaces.dtos.StarndardResponse.StandardResponse;
+import com.hextech.estoque_api.interfaces.dtos.dashboard.DashboardDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/dashboard", produces = "application/json")
+public class DashboardController {
+
+    @Autowired
+    private AuthContext authContext;
+    @Autowired
+    private DashboardService service;
+
+    @GetMapping
+    public ResponseEntity<StandardResponse<?>> getDashboard() {
+        DashboardDTO response = service.getDashboard(authContext.getCurrentCompanyId());
+        return ResponseEntity.ok(new StandardResponse<>(true, response));
+    }
+}

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/docs/DashboardControllerDocs.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/controllers/docs/DashboardControllerDocs.java
@@ -1,0 +1,18 @@
+package com.hextech.estoque_api.interfaces.controllers.docs;
+
+import com.hextech.estoque_api.interfaces.dtos.StarndardResponse.StandardResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+
+public interface DashboardControllerDocs {
+
+    @Operation(summary = "Retorna as informações do dashboard")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = StandardResponse.class)))
+    })
+    ResponseEntity<StandardResponse<?>> getDashboard();
+}

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/dashboard/DashboardDTO.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/dashboard/DashboardDTO.java
@@ -1,0 +1,11 @@
+package com.hextech.estoque_api.interfaces.dtos.dashboard;
+
+import com.hextech.estoque_api.interfaces.dtos.movements.MovementMinDTO;
+import com.hextech.estoque_api.interfaces.dtos.products.ProductResumeDTO;
+
+import java.util.List;
+
+public record DashboardDTO(Long totalProducts, Long lowStockCount, Long totalMovements,
+                           List<MovementMinDTO> recentMovements, List<TopMovingProducts> topMovingProducts,
+                           List<ProductResumeDTO> lowStockProducts) {
+}

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/dashboard/TopMovingProducts.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/dashboard/TopMovingProducts.java
@@ -1,0 +1,11 @@
+package com.hextech.estoque_api.interfaces.dtos.dashboard;
+
+import com.hextech.estoque_api.domain.entities.product.Product;
+import com.hextech.estoque_api.interfaces.dtos.products.ProductMinDTO;
+
+public record TopMovingProducts(ProductMinDTO product, Long totalMovements) {
+
+    public TopMovingProducts(Product product, Long totalMovements) {
+        this(new ProductMinDTO(product), totalMovements);
+    }
+}

--- a/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/movements/MovementMinDTO.java
+++ b/backend/src/main/java/com/hextech/estoque_api/interfaces/dtos/movements/MovementMinDTO.java
@@ -1,0 +1,22 @@
+package com.hextech.estoque_api.interfaces.dtos.movements;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hextech.estoque_api.domain.entities.movement.Movement;
+import com.hextech.estoque_api.interfaces.dtos.products.ProductMinDTO;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record MovementMinDTO(
+        Long id,
+        LocalDateTime moment,
+        String type,
+        BigDecimal quantity,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        ProductMinDTO product
+) {
+        public MovementMinDTO(Movement entity) {
+                this(entity.getId(), entity.getMoment(), entity.getType().toString(), entity.getQuantity(),
+                        new ProductMinDTO(entity.getProduct()));
+        }
+}

--- a/backend/src/test/java/com/hextech/estoque_api/application/services/DashboardServiceTest.java
+++ b/backend/src/test/java/com/hextech/estoque_api/application/services/DashboardServiceTest.java
@@ -1,0 +1,102 @@
+package com.hextech.estoque_api.application.services;
+
+import com.hextech.estoque_api.application.tests.MovementFactory;
+import com.hextech.estoque_api.application.tests.ProductFactory;
+import com.hextech.estoque_api.domain.entities.movement.Movement;
+import com.hextech.estoque_api.domain.entities.product.Product;
+import com.hextech.estoque_api.infrastructure.repositories.MovementRepository;
+import com.hextech.estoque_api.infrastructure.repositories.ProductRepository;
+import com.hextech.estoque_api.interfaces.dtos.dashboard.DashboardDTO;
+import com.hextech.estoque_api.interfaces.dtos.dashboard.TopMovingProducts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private MovementRepository movementRepository;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    private Long companyId;
+    private Product product1;
+    private Product product2;
+    private Movement movement1;
+    private Movement movement2;
+    private TopMovingProducts topMovingProduct1;
+    private TopMovingProducts topMovingProduct2;
+
+    @BeforeEach
+    void setUp() {
+        companyId = 1L;
+
+        product1 = ProductFactory.createProduct(1L);
+        product2 = ProductFactory.createProduct(2L);
+
+        movement1 = MovementFactory.createEntryMovement();
+        movement2 = MovementFactory.createExitMovement();
+
+        topMovingProduct1 = new TopMovingProducts(product1, 10L);
+        topMovingProduct2 = new TopMovingProducts(product2, 8L);
+    }
+
+    @Test
+    void getDashboard_shouldReturnCorrectDashboardDTO() {
+        // Arrange
+        when(productRepository.countByCompanyId(anyLong())).thenReturn(2L);
+        when(productRepository.countByCompanyIdAndStockStatus(anyLong(), anyString())).thenReturn(1L);
+        when(productRepository.findTop5ByStockStatus(anyLong(), anyString(), any(PageRequest.class)))
+                .thenReturn(Collections.singletonList(product1));
+        when(movementRepository.countByCompanyId(anyLong())).thenReturn(2L);
+        when(movementRepository.findTop5ByCompanyIdOrderByMomentDesc(anyLong()))
+                .thenReturn(Arrays.asList(movement1, movement2));
+        when(movementRepository.findMostMovedProducts(anyLong(), any(PageRequest.class)))
+                .thenReturn(Arrays.asList(topMovingProduct1, topMovingProduct2));
+
+        // Act
+        DashboardDTO result = dashboardService.getDashboard(companyId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2L, result.totalProducts());
+        assertEquals(1L, result.lowStockCount());
+        assertEquals(2L, result.totalMovements());
+        assertEquals(2, result.recentMovements().size());
+        assertEquals(product1.getName(), result.recentMovements().get(0).product().name());
+        assertEquals(product1.getName(), result.recentMovements().get(1).product().name());
+        assertEquals(2, result.topMovingProducts().size());
+        assertEquals(product1.getName(), result.topMovingProducts().get(0).product().name());
+        assertEquals(product2.getName(), result.topMovingProducts().get(1).product().name());
+        assertEquals(1, result.lowStockProducts().size());
+        assertEquals(product1.getName(), result.lowStockProducts().get(0).getName());
+        verify(productRepository, times(1)).countByCompanyId(eq(companyId));
+        verify(productRepository, times(1))
+                .countByCompanyIdAndStockStatus(eq(companyId), eq("LOW"));
+        verify(productRepository, times(1))
+                .findTop5ByStockStatus(eq(companyId), eq("LOW"), any(Pageable.class));
+        verify(movementRepository, times(1)).countByCompanyId(eq(companyId));
+        verify(movementRepository, times(1))
+                .findTop5ByCompanyIdOrderByMomentDesc(eq(companyId));
+        verify(movementRepository, times(1))
+                .findMostMovedProducts(eq(companyId), any(PageRequest.class));
+    }
+}


### PR DESCRIPTION
# 📊 feat: implementa endpoint de dashboard

## Descrição

Implementa endpoint de dashboard para centralizar métricas e informações resumidas do sistema de estoque.

O endpoint retorna:

* Total de produtos cadastrados;
* Quantidade de produtos com estoque baixo;
* Total de movimentações;
* Últimas movimentações;
* Produtos mais movimentados;
* Produtos com estoque baixo.

Também foram adicionados testes unitários para validação das regras do `DashboardService`.

---

## 🚀 Endpoint

`GET /dashboard`

---

## 🛠️ Implementações

* Criação do `DashboardController`;
* Criação do `DashboardService`;
* Criação dos DTOs de dashboard;
* Consultas para métricas e listagens;
* Integração das informações em uma única resposta;
* Adição de testes unitários do `DashboardService`.

---

## 🧪 Testes

* Testes unitários adicionados para o `DashboardService`;
* Validação das métricas e listagens retornadas pelo endpoint.
